### PR TITLE
fix: stream proxy, status tracking, and Range seek bugs

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -29,8 +29,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GHCR_TOKEN }}
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3

--- a/pkg/server/xtream_handlers_stream.go
+++ b/pkg/server/xtream_handlers_stream.go
@@ -34,7 +34,6 @@ import (
     "time"
 
     "github.com/gin-gonic/gin"
-    "github.com/jamesnetherton/m3u"
     "github.com/lucasduport/stream-share/pkg/types"
     "github.com/lucasduport/stream-share/pkg/utils"
     xtreamapi "github.com/lucasduport/stream-share/pkg/xtream"
@@ -91,38 +90,7 @@ func (c *Config) xtreamStream(ctx *gin.Context, oriURL *url.URL) {
         return
     }
 
-    utils.DebugLog("Xtream backend request using Xtream credentials: user=%s, password=%s, baseURL=%s", c.XtreamUser.String(), c.XtreamPassword.String(), c.XtreamBaseURL)
-    rawURL := fmt.Sprintf("%s/get.php?username=%s&password=%s", c.XtreamBaseURL, c.XtreamUser, c.XtreamPassword)
-
-    q := ctx.Request.URL.Query()
-    for k, v := range q {
-        if k == "username" || k == "password" { continue }
-        rawURL = fmt.Sprintf("%s&%s=%s", rawURL, k, strings.Join(v, ","))
-    }
-
-    m3uURL, err := url.Parse(rawURL)
-    if err != nil { _ = ctx.AbortWithError(http.StatusInternalServerError, utils.PrintErrorAndReturn(err)); return }
-
-    xtreamM3uCacheLock.RLock()
-    meta, ok := xtreamM3uCache[m3uURL.String()]
-    d := time.Since(meta.Time)
-    if !ok || d.Hours() >= float64(c.M3UCacheExpiration) {
-        utils.InfoLog("xtream cache m3u file refresh requested by %s", ctx.ClientIP())
-        xtreamM3uCacheLock.RUnlock()
-        playlist, err := m3u.Parse(m3uURL.String())
-        if err != nil { _ = ctx.AbortWithError(http.StatusInternalServerError, utils.PrintErrorAndReturn(err)); return }
-        if len(playlist.Tracks) == 0 { _ = ctx.AbortWithError(http.StatusBadGateway, utils.PrintErrorAndReturn(fmt.Errorf("Xtream backend returned empty playlist"))); return }
-        if err := c.cacheXtreamM3u(&playlist, m3uURL.String()); err != nil { _ = ctx.AbortWithError(http.StatusInternalServerError, utils.PrintErrorAndReturn(err)); return }
-    } else {
-        xtreamM3uCacheLock.RUnlock()
-    }
-
-    ctx.Header("Content-Disposition", fmt.Sprintf(`attachment; filename=%q`, c.M3UFileName))
-    xtreamM3uCacheLock.RLock()
-    path := xtreamM3uCache[m3uURL.String()].string
-    xtreamM3uCacheLock.RUnlock()
-    ctx.Header("Content-Type", "application/octet-stream")
-    ctx.File(path)
+    c.stream(ctx, oriURL)
 }
 
 func (c *Config) xtreamXMLTV(ctx *gin.Context) {

--- a/pkg/server/xtream_handlers_stream.go
+++ b/pkg/server/xtream_handlers_stream.go
@@ -168,6 +168,14 @@ func (c *Config) xtreamStreamMovie(ctx *gin.Context) {
     id := ctx.Param("id")
     // Normalize DB key: cached entries are stored by bare stream_id without extension
     idRaw := strings.TrimSuffix(id, path.Ext(id))
+    if c.sessionManager != nil {
+        username := ctx.GetString("username")
+        if username == "" { username = ctx.Param("username") }
+        if username != "" {
+            c.sessionManager.RegisterVODView(username, idRaw, "movie", idRaw)
+            defer c.sessionManager.UnregisterVODView(username, idRaw)
+        }
+    }
     if c.db != nil {
         if entry, err := c.db.GetVODCache(idRaw); err == nil && entry != nil {
             // If file exists and is ready, serve locally; if downloading, serve progressively from .part
@@ -222,6 +230,14 @@ func (c *Config) xtreamStreamMovie(ctx *gin.Context) {
 func (c *Config) xtreamStreamSeries(ctx *gin.Context) {
     id := ctx.Param("id")
     idRaw := strings.TrimSuffix(id, path.Ext(id))
+    if c.sessionManager != nil {
+        username := ctx.GetString("username")
+        if username == "" { username = ctx.Param("username") }
+        if username != "" {
+            c.sessionManager.RegisterVODView(username, idRaw, "series", idRaw)
+            defer c.sessionManager.UnregisterVODView(username, idRaw)
+        }
+    }
     if c.db != nil {
         if entry, err := c.db.GetVODCache(idRaw); err == nil && entry != nil {
             if fi, statErr := os.Stat(entry.FilePath); statErr == nil && !fi.IsDir() {
@@ -288,6 +304,14 @@ func (c *Config) xtreamProxyCredentialsMovieStreamHandler(ctx *gin.Context) {
     id := ctx.Param("id")
     idRaw := strings.TrimSuffix(id, path.Ext(id))
     utils.DebugLog("Direct movie stream request with proxy credentials: username=%s, id=%s", ctx.Param("username"), id)
+    if c.sessionManager != nil {
+        username := ctx.GetString("username")
+        if username == "" { username = ctx.Param("username") }
+        if username != "" {
+            c.sessionManager.RegisterVODView(username, idRaw, "movie", idRaw)
+            defer c.sessionManager.UnregisterVODView(username, idRaw)
+        }
+    }
     if c.db != nil {
         if entry, err := c.db.GetVODCache(idRaw); err == nil && entry != nil {
             if fi, statErr := os.Stat(entry.FilePath); statErr == nil && !fi.IsDir() {
@@ -337,6 +361,14 @@ func (c *Config) xtreamProxyCredentialsSeriesStreamHandler(ctx *gin.Context) {
     id := ctx.Param("id")
     idRaw := strings.TrimSuffix(id, path.Ext(id))
     utils.DebugLog("Direct series stream request with proxy credentials: username=%s, id=%s", ctx.Param("username"), id)
+    if c.sessionManager != nil {
+        username := ctx.GetString("username")
+        if username == "" { username = ctx.Param("username") }
+        if username != "" {
+            c.sessionManager.RegisterVODView(username, idRaw, "series", idRaw)
+            defer c.sessionManager.UnregisterVODView(username, idRaw)
+        }
+    }
     if c.db != nil {
         if entry, err := c.db.GetVODCache(idRaw); err == nil && entry != nil {
             if fi, statErr := os.Stat(entry.FilePath); statErr == nil && !fi.IsDir() {
@@ -619,11 +651,17 @@ func serveGrowingFileRange(ctx *gin.Context, filePath string, contentType string
         ctx.Status(http.StatusRequestedRangeNotSatisfiable)
         return
     }
-    // If requested start or end goes beyond available bytes, wait for growth (only when .part exists)
+
+    // Detect open-ended range (bytes=N-): player is seeking and wants everything from N onwards.
+    // Do NOT wait for end < sizeNow in this case — that would block until the full download finishes.
+    rawSpec := strings.TrimSpace(strings.TrimPrefix(strings.ToLower(strings.TrimSpace(rng)), "bytes="))
+    if idx := strings.Index(rawSpec, ","); idx >= 0 { rawSpec = rawSpec[:idx] }
+    openEnded := strings.HasSuffix(strings.TrimSpace(rawSpec), "-")
+
+    // Wait until start is available; for bounded ranges also wait for end.
     for {
         sizeNow = getSize()
-        if start < sizeNow && end < sizeNow { break }
-        // If no longer downloading, clamp end
+        if start < sizeNow && (openEnded || end < sizeNow) { break }
         if _, err := os.Stat(partPath); err != nil {
             if sizeNow == 0 || start >= sizeNow {
                 ctx.Header("Content-Range", fmt.Sprintf("bytes */%d", sizeNow))
@@ -631,9 +669,9 @@ func serveGrowingFileRange(ctx *gin.Context, filePath string, contentType string
                 return
             }
             if end >= sizeNow { end = sizeNow - 1 }
+            openEnded = false // download done; treat as bounded
             break
         }
-        // Still downloading; wait for more data or cancel
         select {
         case <-ctx.Request.Context().Done():
             return
@@ -641,16 +679,55 @@ func serveGrowingFileRange(ctx *gin.Context, filePath string, contentType string
         }
     }
 
-    // Ready to serve the requested (possibly clamped) range
-    length := end - start + 1
     if _, err := f.Seek(start, io.SeekStart); err != nil { ctx.Status(http.StatusInternalServerError); return }
-    tot := totalSize
-    if tot == 0 { tot = max64(totalSize, getSize()) }
-    ctx.Header("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, tot))
+
+    if openEnded {
+        // Open-ended seek: stream progressively from start, waiting for file growth.
+        // Use known totalSize or '*' to avoid telling the player the file ends at current download offset.
+        curEnd := getSize() - 1
+        if curEnd < start { curEnd = start }
+        totStr := "*"
+        if totalSize > 0 { totStr = strconv.FormatInt(totalSize, 10) }
+        ctx.Header("Content-Range", fmt.Sprintf("bytes %d-%d/%s", start, curEnd, totStr))
+        ctx.Status(http.StatusPartialContent)
+        var offset int64 = start
+        buf := make([]byte, 256*1024)
+        for {
+            if cur, _ := f.Seek(0, io.SeekCurrent); cur != offset {
+                if _, err := f.Seek(offset, io.SeekStart); err != nil { return }
+            }
+            n, _ := f.Read(buf)
+            if n > 0 {
+                if _, werr := ctx.Writer.Write(buf[:n]); werr != nil { return }
+                offset += int64(n)
+                if fl, ok := ctx.Writer.(http.Flusher); ok { fl.Flush() }
+                continue
+            }
+            if _, err2 := os.Stat(partPath); err2 == nil {
+                select {
+                case <-ctx.Request.Context().Done():
+                    return
+                case <-time.After(200 * time.Millisecond):
+                    continue
+                }
+            }
+            return
+        }
+    }
+
+    // Bounded range: serve exactly the requested bytes.
+    // Use '*' for total when still downloading to avoid reporting partial size as the file's true size.
+    length := end - start + 1
+    totStr := "*"
+    if totalSize > 0 {
+        totStr = strconv.FormatInt(totalSize, 10)
+    } else if _, statErr := os.Stat(partPath); statErr != nil {
+        totStr = strconv.FormatInt(getSize(), 10) // download complete; use actual size
+    }
+    ctx.Header("Content-Range", fmt.Sprintf("bytes %d-%d/%s", start, end, totStr))
     ctx.Header("Content-Length", strconv.FormatInt(length, 10))
     ctx.Status(http.StatusPartialContent)
 
-    // Stream exactly length bytes; tolerate short reads by waiting while downloading
     var remaining = length
     buf := make([]byte, 256*1024)
     for remaining > 0 {
@@ -664,7 +741,6 @@ func serveGrowingFileRange(ctx *gin.Context, filePath string, contentType string
             continue
         }
         if err == io.EOF || err == io.ErrUnexpectedEOF {
-            // If still downloading, wait and retry
             if _, statErr := os.Stat(partPath); statErr == nil {
                 select {
                 case <-ctx.Request.Context().Done():
@@ -673,7 +749,6 @@ func serveGrowingFileRange(ctx *gin.Context, filePath string, contentType string
                     continue
                 }
             }
-            // Not downloading anymore: stop
             return
         }
         if err != nil {

--- a/pkg/session/manager.go
+++ b/pkg/session/manager.go
@@ -721,6 +721,51 @@ func (sm *SessionManager) DisconnectUser(username string) {
 	utils.InfoLog("User %s forcibly disconnected", username)
 }
 
+// RegisterVODView creates a synthetic stream session so status commands see users watching local files.
+func (sm *SessionManager) RegisterVODView(username, streamID, streamType, title string) {
+	sm.userLock.Lock()
+	if sess, exists := sm.userSessions[username]; exists {
+		sess.StreamID = streamID
+		sess.StreamType = streamType
+		sess.LastActive = time.Now()
+	}
+	sm.userLock.Unlock()
+
+	sm.streamLock.Lock()
+	defer sm.streamLock.Unlock()
+	if ss, exists := sm.streamSessions[streamID]; exists {
+		ss.AddViewer(username)
+		ss.LastRequested = time.Now()
+	} else {
+		ss := &types.StreamSession{
+			StreamID: streamID, StreamType: streamType, StreamTitle: title,
+			StartTime: time.Now(), LastRequested: time.Now(),
+			Viewers: make(map[string]time.Time), Active: true,
+		}
+		ss.AddViewer(username)
+		sm.streamSessions[streamID] = ss
+	}
+}
+
+// UnregisterVODView removes a user from a synthetic VOD viewing session.
+func (sm *SessionManager) UnregisterVODView(username, streamID string) {
+	sm.userLock.Lock()
+	if sess, exists := sm.userSessions[username]; exists && sess.StreamID == streamID {
+		sess.StreamID = ""
+		sess.StreamType = ""
+	}
+	sm.userLock.Unlock()
+
+	sm.streamLock.Lock()
+	defer sm.streamLock.Unlock()
+	if ss, exists := sm.streamSessions[streamID]; exists {
+		if !ss.RemoveViewer(username) {
+			ss.Active = false
+			delete(sm.streamSessions, streamID)
+		}
+	}
+}
+
 // GetStreamInfo gets information about a specific stream
 func (sm *SessionManager) GetStreamInfo(streamID string) (*types.StreamSession, bool) {
 	sm.streamLock.RLock()


### PR DESCRIPTION
## Summary

- **Critical: live streams and non-cached movies returned M3U instead of video** — `xtreamStream` had M3U-serving code copy-pasted from `xtreamGet`, ignoring the `oriURL` parameter entirely when `FORCE_MULTIPLEXING` was not set. Every live channel and non-cached VOD request sent an M3U playlist to the player, causing `avformat can't open input / Input/output error`.
- **Status command showed 0 active streams/users for VOD** — `serveGrowingFileRange`/`serveLocalFileRange` serve files directly without going through `RequestStream`, so the session manager never knew anyone was watching. Added `RegisterVODView`/`UnregisterVODView` to the session manager and call them (with `defer`) in all four VOD stream handlers.
- **Seeking before cache is ready caused crash (jump-to-end loop)** — Two bugs in `serveGrowingFileRange`: (1) open-ended Range requests (`bytes=N-`) set `end = 1<<60-1`, making the wait loop block until the full file was downloaded; (2) `Content-Range` reported the current partial download size as the file's total size, causing the player to think the movie ended early. Fixed by detecting open-ended ranges and streaming progressively from the seek point, and using `*` for unknown total in `Content-Range`.

## Test plan

- [ ] Open a live channel — should play immediately without `avformat` errors
- [ ] Open a movie that is not yet cached — should start playing and buffer normally
- [ ] While a movie is downloading, seek 30s ahead — should resume from the new position without jumping to the end
- [ ] Run `/status` while watching a movie — should show the active user and stream