### PR TITLE
fix: stop injecting Range on VOD/live and fix avformat errors

### DIFF
--- a/pkg/server/helpers.go
+++ b/pkg/server/helpers.go
@@ -40,8 +40,10 @@ func prepareVODHeaders(ctx *gin.Context) http.Header {
     if v := ctx.Request.Header.Get("Accept"); v != "" { clean.Set("Accept", v) } else { clean.Set("Accept", "*/*") }
     // Accept-Language
     if v := ctx.Request.Header.Get("Accept-Language"); v != "" { clean.Set("Accept-Language", v) } else { clean.Set("Accept-Language", utils.GetLanguageHeader()) }
-    // Range
-    if v := ctx.Request.Header.Get("Range"); v != "" { clean.Set("Range", v) } else { clean.Set("Range", "bytes=0-") }
+    // Range — only forward if the client actually sent it; do not inject bytes=0- because
+    // that forces a 206 response which may lack a Content-Range total, leaving the player
+    // unable to determine file size and triggering avformat errors.
+    if v := ctx.Request.Header.Get("Range"); v != "" { clean.Set("Range", v) }
     // Connection
     clean.Set("Connection", "keep-alive")
     // UA and encoding
@@ -52,6 +54,11 @@ func prepareVODHeaders(ctx *gin.Context) http.Header {
 
 func isVODPath(p string) bool {
     lp := strings.ToLower(p)
+    // Live, timeshift, and HLS are never VOD even if they end in .ts
+    if strings.Contains(lp, "/live/") || strings.Contains(lp, "/timeshift/") ||
+        strings.Contains(lp, "/hls/") || strings.Contains(lp, "/hlsr/") || strings.Contains(lp, "/play/") {
+        return false
+    }
     if strings.Contains(lp, "/movie/") || strings.Contains(lp, "/series/") {
         return true
     }

--- a/pkg/server/xtream_handlers_stream.go
+++ b/pkg/server/xtream_handlers_stream.go
@@ -359,7 +359,7 @@ func (c *Config) xtreamProxyCredentialsMovieStreamHandler(ctx *gin.Context) {
     }
     rpURL, err := url.Parse(fmt.Sprintf("%s/movie/%s/%s/%s", c.XtreamBaseURL, c.XtreamUser, c.XtreamPassword, id))
     if err != nil { utils.ErrorLog("Failed to parse upstream URL: %v", err); ctx.AbortWithStatus(500); return }
-    c.multiplexedStream(ctx, rpURL)
+    c.stream(ctx, rpURL)
 }
 
 func (c *Config) xtreamProxyCredentialsSeriesStreamHandler(ctx *gin.Context) {
@@ -428,7 +428,7 @@ func (c *Config) xtreamProxyCredentialsSeriesStreamHandler(ctx *gin.Context) {
     }
     rpURL, err := url.Parse(fmt.Sprintf("%s/series/%s/%s/%s", c.XtreamBaseURL, c.XtreamUser, c.XtreamPassword, id))
     if err != nil { utils.ErrorLog("Failed to parse upstream URL: %v", err); ctx.AbortWithStatus(500); return }
-    c.multiplexedStream(ctx, rpURL)
+    c.stream(ctx, rpURL)
 }
 
 // HLS helpers and handlers

--- a/pkg/session/manager.go
+++ b/pkg/session/manager.go
@@ -26,7 +26,6 @@ import (
 	"net/url"
 	"sync"
 	"time"
-	"strings"
 
 	"github.com/google/uuid"
 	"github.com/lucasduport/stream-share/pkg/database"
@@ -466,23 +465,14 @@ func (sm *SessionManager) streamToClients(buffer *StreamBuffer, upstreamURL *url
 		return
 	}
 
-	// Set headers; for VOD/series use a strict whitelist header set
-	isVOD := strings.Contains(upstreamURL.Path, "/movie/") || strings.Contains(upstreamURL.Path, "/series/")
-	if isVOD {
-		h := http.Header{}
-		h.Set("User-Agent", utils.GetIPTVUserAgent())
-		h.Set("Accept", "*/*")
-	h.Set("Accept-Language", utils.GetLanguageHeader())
-		h.Set("Accept-Encoding", "identity")
-		h.Set("Connection", "keep-alive")
-		h.Set("Range", "bytes=0-")
-		req.Header = h
-	} else {
-		req.Header.Set("User-Agent", utils.GetIPTVUserAgent())
-		req.Header.Set("Accept", "*/*")
-		req.Header.Set("Accept-Encoding", "identity")
-		req.Header.Set("Connection", "keep-alive")
-	}
+	// Set common headers; never inject Range — let the upstream return a natural 200
+	// with Content-Length so clients can seek. Injecting bytes=0- forces a 206 response
+	// which may lack a Content-Range total and causes avformat errors in media players.
+	req.Header.Set("User-Agent", utils.GetIPTVUserAgent())
+	req.Header.Set("Accept", "*/*")
+	req.Header.Set("Accept-Language", utils.GetLanguageHeader())
+	req.Header.Set("Accept-Encoding", "identity")
+	req.Header.Set("Connection", "keep-alive")
 
 	resp, err := sm.httpClient.Do(req)
 	if err != nil {
@@ -492,21 +482,12 @@ func (sm *SessionManager) streamToClients(buffer *StreamBuffer, upstreamURL *url
 	}
 	defer resp.Body.Close()
 
-	// Check if response is successful. For VOD with Range requests, 206 is valid.
-	if isVOD {
-		if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusPartialContent {
-			utils.ErrorLog("Upstream returned status %d for VOD stream %s",
-				resp.StatusCode, buffer.streamID)
-			sm.stopStream(buffer.streamID)
-			return
-		}
-	} else {
-		if resp.StatusCode != http.StatusOK {
-			utils.ErrorLog("Upstream returned status %d for stream %s",
-				resp.StatusCode, buffer.streamID)
-			sm.stopStream(buffer.streamID)
-			return
-		}
+	// Accept 200 (expected) and 206 (some providers return it unconditionally).
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusPartialContent {
+		utils.ErrorLog("Upstream returned status %d for stream %s",
+			resp.StatusCode, buffer.streamID)
+		sm.stopStream(buffer.streamID)
+		return
 	}
 
 	// Stream data into ring buffer


### PR DESCRIPTION
## Summary

- **`isVODPath`**: `/live/`, `/timeshift/`, `/hls/`, `/hlsr/`, `/play/` paths are now excluded from VOD detection even if they end in `.ts`. A `.ts` live stream was being treated as VOD, injecting `Range: bytes=0-` which many live stream providers reject (416/error), causing avformat errors.

- **`prepareVODHeaders`**: Removed unconditional `Range: bytes=0-` injection. Only forwards the client's Range header if one was sent. Previously, injecting `bytes=0-` forced a 206 response from the upstream. If the provider's 206 lacked a `Content-Range` header with a total, our normalization couldn't extract `Content-Length`, leaving the player blind to file size → avformat error for MP4 with moov at EOF.

- **`session/manager.go` `streamToClients`**: Same Range injection removed. Unified status check to accept 200 and 206 regardless of stream type.

- **`xtreamProxyCredentialsMovieStreamHandler` / `xtreamProxyCredentialsSeriesStreamHandler`** no-DB fallback: Changed from `c.multiplexedStream()` to `c.stream()`. The multiplexed path sends chunked responses with no `Content-Length` or `Accept-Ranges`, making seeking impossible for movies.

The 206→200 normalization in `proxy_handlers.go` is kept as a safety net for providers that return 206 unconditionally.

## Test plan

- [ ] Start an uncached movie → should play without avformat error, seeking should work
- [ ] Start a live stream with `.ts` ID → should play without avformat error
- [ ] Seek in an uncached movie during first play → no seek loop
- [ ] Second play of a cached movie → served from local file, full seeking